### PR TITLE
docs: explicitly state exit codes for exit-if-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you specify multiple `--file` options, the command will run if _any_ of the `
 
 ### `exit-if-diff`
 
-Exit if files have changed.
+Exit with code `128` if files have changed and with code `0` otherwise.
 
 #### Options
 


### PR DESCRIPTION
Thought it would save other people some time looking in the source for the exit codes.
Also there are some outdated packages and 66 low severity vulnerabilities to be fixed. If you want I can add them here.